### PR TITLE
Fixed meta element "msapplication-config" not being removed from the HTML

### DIFF
--- a/tasks/real_favicon.js
+++ b/tasks/real_favicon.js
@@ -27,7 +27,7 @@ module.exports = function(grunt) {
       var name = $(this).attr('name');
       if (name && (name === 'msapplication-TileImage' ||
                 name === 'msapplication-TileColor' ||
-                name.indexOf('msapplication-square') >= 0)) {
+                name === 'msapplication-config')) {
         $(this).remove();
       }
     });

--- a/test/expected/scenario_1/page2.html
+++ b/test/expected/scenario_1/page2.html
@@ -17,7 +17,7 @@
     
     
     
-    <meta name="msapplication-config" content="/path/to/some/icons/browserconfig.xml">
+    
   <link rel="shortcut icon" href="/path/to/icons/favicon.ico">
 <link rel="apple-touch-icon" sizes="57x57" href="/path/to/icons/apple-touch-icon-57x57.png">
 <link rel="apple-touch-icon" sizes="114x114" href="/path/to/icons/apple-touch-icon-114x114.png">

--- a/test/expected/scenario_2/page2.html
+++ b/test/expected/scenario_2/page2.html
@@ -17,7 +17,7 @@
     
     
     
-    <meta name="msapplication-config" content="/path/to/some/icons/browserconfig.xml">
+    
   <link rel="apple-touch-icon" sizes="57x57" href="/apple-touch-icon-57x57.png">
 <link rel="apple-touch-icon" sizes="114x114" href="/apple-touch-icon-114x114.png">
 <link rel="apple-touch-icon" sizes="72x72" href="/apple-touch-icon-72x72.png">

--- a/test/expected/scenario_3/page2.html
+++ b/test/expected/scenario_3/page2.html
@@ -17,7 +17,7 @@
     
     
     
-    <meta name="msapplication-config" content="/path/to/some/icons/browserconfig.xml">
+    
   <link rel="shortcut icon" href="/yet/another/path/favicon.ico">
 <link rel="apple-touch-icon" sizes="57x57" href="/yet/another/path/apple-touch-icon-57x57.png">
 <link rel="apple-touch-icon" sizes="114x114" href="/yet/another/path/apple-touch-icon-114x114.png">


### PR DESCRIPTION
In `tasks/real_favicon.js`, when the `link` and `meta` tags are being removed from the `head` of the HTML files before the new ones are inserted, it looks like the script was removing the meta `msapplication-square*` instead of `msapplication-config` resulting in the original `<meta name="msapplication-config" content="/path/to/some/icons/browserconfig.xml">` not being removed and sometimes being duplicated in the head.

I've updated the tests as well so they pass with the change to `tasks/real_favicon.js`. Thanks for this excellent site and Grunt plugin.
