### PR TITLE
Add ability for iconsPath option to be a callback

### DIFF
--- a/tasks/real_favicon.js
+++ b/tasks/real_favicon.js
@@ -54,64 +54,105 @@ module.exports = function(grunt) {
   }
 
   var generateFavicon = function() {
+    var options = this.options();
+    var source = this.data.src;
+    var destination = this.data.dest;
     var done = this.async();
-    var html_files = this.options().html || [];
+    var html_files = options.html || [];
 
     // Build favicon generation request
     var request = {};
     request.api_key = 'f26d432783a1856427f32ed8793e1d457cc120f1';
     // Master picture
     request.master_picture = {};
-    if (isUrl(this.data.src)) {
+    if (isUrl(source)) {
       request.master_picture.type = 'url';
-      request.master_picture.url = this.data.src;
+      request.master_picture.url = source;
     }
     else {
       request.master_picture.type = 'inline';
-      request.master_picture.content = rfg.fileToBase64Sync(this.data.src);
+      request.master_picture.content = rfg.fileToBase64Sync(source);
     }
+
     // Path
     request.files_location = {};
-    if (this.options().iconsPath === undefined) {
+    if (options.iconsPath === undefined) {
       request.files_location.type = 'root';
     }
     else {
+      // Allow iconsPath to be a callback function to dynamically generate path.
+      if (typeof options.iconsPath === 'function') {
+        options.iconsPathCallback = options.iconsPath;
+      }
+
+      // Ensure iconsPath is always set to a special path when iconsPathCallback is present.
+      if (typeof options.iconsPathCallback === 'function') {
+        options.iconsPath = '{{RFG-PATH-CALLBACK}}';
+
+        // Create a regular expression to use for iconsPathCallback.
+        options.iconsPathRegExp = new RegExp(options.iconsPath + '([^"]+)', 'gm');
+      }
+
       request.files_location.type = 'path';
-      request.files_location.path = this.options().iconsPath;
+      request.files_location.path = options.iconsPath;
     }
+
     // Design
     request.favicon_design = normalizeAllMasterPictures(
-      rfg.camelCaseToUnderscoreRequest(this.options().design));
+      rfg.camelCaseToUnderscoreRequest(options.design));
 
     // Settings
-    request.settings = rfg.camelCaseToUnderscoreRequest(this.options().settings);
+    request.settings = rfg.camelCaseToUnderscoreRequest(options.settings);
 
     // Versioning
-    request.versioning = rfg.camelCaseToUnderscoreRequest(this.options().versioning);
+    request.versioning = rfg.camelCaseToUnderscoreRequest(options.versioning);
 
-    rfg.generateFavicon(request, this.data.dest, function(error, favicon) {
+    grunt.log.write('Generating "' + source + '" favicon...');
+    rfg.generateFavicon(request, destination, function(error, favicon) {
+      // Indicate error.
       if (error !== undefined) {
+        grunt.log.warn();
         grunt.log.error(error);
         grunt.log.debug("The RFG API request was: " + JSON.stringify(favicon));
-
         throw error;
       }
 
-      async.each(grunt.file.expand({nonull: true}, html_files), function(file, callback) {
-        grunt.log.writeln("Process " + file);
+      // Indicate success.
+      grunt.log.ok();
 
-        if (! grunt.file.exists(file)) {
-          grunt.log.debug("File '" + file + "' does not exist, create it and populate it with the markups");
-          grunt.file.write(file, favicon.favicon.html_code);
+      // Handle dynamic iconsPathCallback in browserconfig.xml and manifest.json.
+      if (options.iconsPathCallback && options.iconsPathRegExp) {
+        var config = [destination + '/browserconfig.xml', destination + '/manifest.json'];
+        var contents;
+        for (var i = 0, l = config.length; i < l; i++) {
+          if (grunt.file.exists(config[i])) {
+            grunt.log.debug('Post processing "' + config[i] + '"...');
+            contents = grunt.file.read(config[i]);
+            grunt.file.write(config[i], contents.replace(options.iconsPathRegExp, function (match, href) {
+              return options.iconsPathCallback.call(this, href, config[i]);
+            }));
+          }
+        }
+      }
+
+      async.each(grunt.file.expand({nonull: true}, html_files), function(file, callback) {
+        // Create a blank file if it does not exist.
+        if (!grunt.file.exists(file)) {
+          grunt.log.debug('The file "' + file + '" does not exist, creating the file so markup can be injected.');
+          grunt.file.write(file, '');
+        }
+
+        grunt.log.writeln('Injecting markup into file: ' + file);
+        rfg.injectFaviconMarkups(file, favicon.favicon.html_code, {}, function(error, code) {
+          // Handle dynamic iconPathsCallback.
+          if (options.iconsPathCallback && options.iconsPathRegExp) {
+            code = code.replace(options.iconsPathRegExp, function (match, href) {
+              return options.iconsPathCallback.call(this, href, file);
+            });
+          }
+          grunt.file.write(file, code);
           callback();
-        }
-        else {
-          grunt.log.debug("File '" + file + "' exists, inject markups in it");
-          rfg.injectFaviconMarkups(file, favicon.favicon.html_code, {}, function(error, code) {
-            grunt.file.write(file, code);
-            callback();
-          });
-        }
+        });
       },
       function() {
         done();

--- a/tasks/real_favicon.js
+++ b/tasks/real_favicon.js
@@ -10,8 +10,9 @@
 
 module.exports = function(grunt) {
 
-  var rfg = require('rfg-api').init(grunt);
   var async = require('async');
+  var path = require('path');
+  var rfg = require('rfg-api').init(grunt);
 
   function startsWith(str, prefix) {
     return str.lastIndexOf(prefix, 0) === 0;
@@ -120,18 +121,16 @@ module.exports = function(grunt) {
       // Indicate success.
       grunt.log.ok();
 
-      // Handle dynamic iconsPathCallback in browserconfig.xml and manifest.json.
+      // Handle dynamic iconsPathCallback for static "json" and "xml" files.
       if (options.iconsPathCallback && options.iconsPathRegExp) {
-        var config = [destination + '/browserconfig.xml', destination + '/manifest.json'];
-        var contents;
-        for (var i = 0, l = config.length; i < l; i++) {
-          if (grunt.file.exists(config[i])) {
-            grunt.log.debug('Post processing "' + config[i] + '"...');
-            contents = grunt.file.read(config[i]);
-            grunt.file.write(config[i], contents.replace(options.iconsPathRegExp, function (match, href) {
-              return options.iconsPathCallback.call(this, href, config[i]);
-            }));
-          }
+        var metaFiles = grunt.file.expand({cwd: destination, filter: 'isFile', matchBase: true, nonull: true}, ['*.json', '*.xml']);
+        for (var i = 0, l = metaFiles.length; i < l; i++) {
+          var file = path.join(destination, metaFiles[i]);
+          grunt.verbose.writeln('Post processing "' + metaFiles[i] + '"...');
+          var content = grunt.file.read(file);
+          grunt.file.write(file, content.replace(options.iconsPathRegExp, function (match, href) {
+            return options.iconsPathCallback.call(this, href, file);
+          }));
         }
       }
 


### PR DESCRIPTION
Fixes #15 

Note: if you're in dire need to use this (until an official release can be made), you can simply require the following:

```bash
npm install grunt-real-favicon@https://github.com/markcarver/grunt-real-favicon/archive/callback.tar.gz --save-dev
```

A complete example using a callback to generate dynamic paths for use in a [Drupal Bootstrap](https://www.drupal.org/project/bootstrap) (twig based) theme:
```js
var fs = require('fs');
var path = require('path');

module.exports = function (grunt) {
  'use strict';

  // Find the absolute local path of the [Drupal] docroot.
  var docroot;
  var directories = __dirname.split(path.sep);
  while (directories.length) {
    docroot = directories.join(path.sep);
    if (fs.existsSync(docroot + path.sep + '/index.php')) {
      break;
    }
    directories.pop();
  }

  // Normalizes a local file system path to be used as URL.
  var pathToUrl = function () {
    return Array.prototype.slice.call(arguments).join('/').replace(/\\+|\/+/g, '/').replace(/\/+/g, '/');
  };

  // Remove the docroot prefix from current directory to determine themeRoot
  // and normalize its local path to be a relative URL.
  var themeRoot = pathToUrl(__dirname.replace(new RegExp('^' + docroot), '')));

  // Create a random string to use as a cache buster in query strings.
  var cacheBuster = Math.random().toString(36).substr(2, 7).toUpperCase();

  var faviconDir = 'img/favicons';

  // Load grunt task(s).
  grunt.loadNpmTasks('grunt-real-favicon');

  // Initialize config for grunt task(s).
  grunt.initConfig({
    realFavicon: {
      favicons: {
        src: 'src/img/favicon.png',
        dest: faviconDir,
        options: {
          /**
           * Returns the path prefix that should be used to generate favicons.
           *
           * @param {String} href
           *   The matched favicon file name.
           * @param {String} file
           *   The source file from which the href came from.
           *
           * @return {String}
           *   A path prefix.
           */
          iconsPath: function (href, file) {
            var json = /\.json$/.test(file);
            var xml = /\.xml$/.test(file);
            // Handle meta files differently since they're static, not processed
            // by the server and require absolute/relative URL paths.
            if (json || xml) {
              href = pathToUrl(themeRoot, faviconDir, href + '?' + cacheBuster);
              // Ensure path separators in manifest.json are properly escaped.
              return json ? href.replace(/\/+/g, '\\/') : href;
            }

            // Otherwise, return Twig output to dynamically generate the path.
            return '{{ file_url(theme.path ~ "/' + grunt.pathToUrl(faviconDir, href) + '?" ~ theme.query_string) }}';
          }
          html: ['templates/system/favicons.html.twig'],
          // Other options.
        }
        // Rest of config.
      }
    }
  });

};
```

Then, in `templates/system/page.html.twig`, include the generated output:
```twig
{% include 'favicons.html.twig' %}
```