### PR TITLE
Use the latest rfg-api

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "async": "^1.4.2",
-    "rfg-api": "^0.4.0"
+    "rfg-api": "^0.5.0"
   },
   "devDependencies": {
     "cheerio": "^0.22.0",


### PR DESCRIPTION
This version does not rely on unzip2 anymore, which contains a high severity vulnerability in fstream dependency.